### PR TITLE
BEL-223777 - Comment history link in tasks is not localized

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onshape/grunt-xgettext",
-  "version": "0.4.0",
+  "version": "0.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@onshape/grunt-xgettext",
-      "version": "0.4.0",
+      "version": "0.4.3",
       "devDependencies": {
         "grunt": "1.4.1"
       },

--- a/tasks/xgettext.js
+++ b/tasks/xgettext.js
@@ -295,12 +295,37 @@ module.exports = function (grunt) {
         mergeTranslationNamespaces(messages, allNamespaces);
       };
 
+      const extractDirective = function (quote, functionName) {
+        const allNamespaces = { messages: {} };
+        const regex = new RegExp(`\\S*=${quote}'(?:\\({(?!}\\)).+}\\))?([^${quote}]+)'\\s\\|\\s${functionName}${quote}`, 'g');
+        let result;
+        do {
+          result = regex.exec(content);
+          if (result !== null) {
+            const string = result[1];
+            allNamespaces.messages[string] = {
+              singular: string,
+              message: '',
+            };
+          }
+        } while (result !== null);
+
+        if (!messageToFilesMap['messages']) {
+          messageToFilesMap['messages'] = {};
+        }
+        Object.keys(allNamespaces.messages).forEach((singularKey) => {
+          messageToFilesMap['messages'][singularKey] = [fileName];
+        });
+        mergeTranslationNamespaces(messages, allNamespaces);
+      };
+
       _.each(fn, (func) => {
         extractStrings("'", func);
         extractStrings('"', func);
         extractDirectiveStrings("'", func);
         extractDirectiveStrings('"', func);
         extractAngular15DirectiveStrings('"', func);
+        extractDirective('"',func);
       });
 
       return [messages, messageToFilesMap];

--- a/tasks/xgettext.js
+++ b/tasks/xgettext.js
@@ -295,9 +295,9 @@ module.exports = function (grunt) {
         mergeTranslationNamespaces(messages, allNamespaces);
       };
 
-      const extractDirective = function (quote, functionName) {
+      const extractAngularJsStringAttributeBinding = function (quote, functionName) {
         const allNamespaces = { messages: {} };
-        const regex = new RegExp(`\\S*=${quote}'(?:\\({(?!}\\)).+}\\))?([^${quote}]+)'\\s\\|\\s${functionName}${quote}`, 'g');
+        const regex = new RegExp(`\\S*=${quote}'([^${quote}]+)'\\s\\|\\s${functionName}${quote}`, 'g');
         let result;
         do {
           result = regex.exec(content);
@@ -325,7 +325,7 @@ module.exports = function (grunt) {
         extractDirectiveStrings("'", func);
         extractDirectiveStrings('"', func);
         extractAngular15DirectiveStrings('"', func);
-        extractDirective('"',func);
+        extractAngularJsStringAttributeBinding('"',func);
       });
 
       return [messages, messageToFilesMap];

--- a/tests/assets/text.html
+++ b/tests/assets/text.html
@@ -4,3 +4,12 @@
   <h4 ng-i18next="[html:i18next]AngularJs - This is a <strong>Html</strong> text"></h4>
   <h4 [innerHtml]="'Angular15 - This is a <strong>traslation</strong> text' | i18next"></h4>
 </div>
+<metadata-property
+    prop="$ctrl.workflowPagePackageProperties.getPropertyById($ctrl.TaskWorkflowProperties.comment)"
+      ctrl="::$ctrl"
+      placeholders="$ctrl.placeholders"
+      metadata-form="::$ctrl.formCtrl"
+      info-text="'(comment history)' | i18next"
+      info-action="$ctrl.showFullComments"
+    ></metadata-property>
+    <div info-text="'(comment history)' | tr"></div>

--- a/tests/assets/text.html
+++ b/tests/assets/text.html
@@ -4,12 +4,4 @@
   <h4 ng-i18next="[html:i18next]AngularJs - This is a <strong>Html</strong> text"></h4>
   <h4 [innerHtml]="'Angular15 - This is a <strong>traslation</strong> text' | i18next"></h4>
 </div>
-<metadata-property
-    prop="$ctrl.workflowPagePackageProperties.getPropertyById($ctrl.TaskWorkflowProperties.comment)"
-      ctrl="::$ctrl"
-      placeholders="$ctrl.placeholders"
-      metadata-form="::$ctrl.formCtrl"
-      info-text="'(comment history)' | i18next"
-      info-action="$ctrl.showFullComments"
-    ></metadata-property>
-    <div info-text="'(comment history)' | tr"></div>
+<div translation-time="'(AngularJs - This is a static string inside an attribute binding)' | tr"></div>

--- a/tests/messages.pot
+++ b/tests/messages.pot
@@ -1,3 +1,12 @@
+msgid "(AngularJs - This is a static string inside an attribute binding)"
+msgstr ""
+
+msgid "Angular15 - This is a <strong>traslation</strong> text"
+msgstr ""
+
+msgid "AngularJs - This is a <strong>Html</strong> text"
+msgstr ""
+
 msgid "Boom"
 msgstr ""
 
@@ -58,10 +67,4 @@ msgid "un"
 msgstr ""
 
 msgid "well hello again, __name__!"
-msgstr ""
-
-msgid "AngularJs - This is a <strong>Html</strong> text"
-msgstr ""
-
-msgid "Angular15 - This is a <strong>traslation</strong> text"
 msgstr ""


### PR DESCRIPTION
Fixing issue with capturing the static string used within angularJs attribute binding.

Created to resolve this [bug](https://belmonttechinc.atlassian.net/browse/BEL-223777).

Example [code](https://github.com/onshape/newton/blob/523ea0e4845bd45ef23c64ff8ddff450fea4623d/project/web/ts/tasks/workflowable-task/task-workflow-property-sheet.ts#L79C5-L86C26) to capture from newton.